### PR TITLE
Conform queue_dequeue to doc.

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -87,6 +87,9 @@ int queue_enqueue(QUEUE *queue, TCB *elem)
 TCB *queue_dequeue(QUEUE *queue)
 {
     struct node *old_head = queue->head;
+    if (old_head == NULL || queue->size == 0) {
+        return NULL;
+    }
     queue->head = queue->head->next;
     queue->size -= 1;
 


### PR DESCRIPTION
The comment specifies that 

```c
/* Remove the first item from the queue and return it. The caller will
   have to free the reuturned element. Returns NULL if the queue is
   empty. */
TCB *queue_dequeue(QUEUE *queue);
```

but `queue->head` is dereferenced no matter what, which segfaults in case of calling queue_dequeue with an empty queue. This PR adds a check and returns NULL in that case.

---

This bug was found by Linus Kämmerer @linus-k519 and Maximilian Giller @mgfcf